### PR TITLE
Add Compatibility for Optional CA Cert

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -47,6 +47,7 @@ module ElasticAPM
       source_lines_span_app_frames: 5,
       source_lines_span_library_frames: 0,
       span_frames_min_duration: '5ms',
+      ssl_ca_cert: nil,
       transaction_max_spans: 500,
       transaction_sample_rate: 1.0,
       verify_server_cert: true,
@@ -92,6 +93,7 @@ module ElasticAPM
       'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES' =>
         [:int, 'source_lines_span_library_frames'],
       'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION' => 'span_frames_min_duration',
+      'ELASTIC_APM_SSL_CA_CERT' => 'ssl_ca_cert',
       'ELASTIC_APM_TRANSACTION_MAX_SPANS' => [:int, 'transaction_max_spans'],
       'ELASTIC_APM_TRANSACTION_SAMPLE_RATE' =>
         [:float, 'transaction_sample_rate'],
@@ -162,6 +164,7 @@ module ElasticAPM
     attr_accessor :source_lines_error_library_frames
     attr_accessor :source_lines_span_app_frames
     attr_accessor :source_lines_span_library_frames
+    attr_accessor :ssl_ca_cert
     attr_accessor :transaction_max_spans
     attr_accessor :transaction_sample_rate
     attr_accessor :verify_server_cert

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -41,6 +41,16 @@ module ElasticAPM
           headers['Authorization'] = "Bearer #{token}"
         end
 
+        # Set SSL CA Cert
+        if config.use_ssl? && config.ssl_ca_cert
+          ssl_ctx = OpenSSL::SSL::SSLContext.new
+          ssl_ctx.ca_file = config.ssl_ca_cert
+
+          # include SSL context in default options
+          client_options = HTTP.default_options.merge(ssl_context: ssl_ctx)
+          HTTP.default_options = client_options
+        end
+
         @client = HTTP.headers(headers).persistent(@url)
 
         @mutex = Mutex.new


### PR DESCRIPTION
Providing a CA cert allows the use of a
self-signed server certificate without disabling
certificate verification.

This adds an optional ssl_ca_cert parameter and
conditionally adds it to the default_options
hash of HTTP.rb. That includes it automatically
in the connection and subsequent requests.

Closes #301.